### PR TITLE
Adding a dynamic title when the user is on another page or tab

### DIFF
--- a/hooks/useChangeTitle.ts
+++ b/hooks/useChangeTitle.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+
+export function useChangeTitle(titleHidden: string = "Don't go, come back! 😢") {
+
+    const [originalTitle, setOriginalTitle] = useState<string>('');
+
+    const handleTabChange = () => {
+        if(document.hidden) document.title = titleHidden;
+        else document.title = originalTitle
+    }
+
+    useEffect(() => {
+
+        if(!originalTitle) setOriginalTitle(document.title);
+
+        window.addEventListener('visibilitychange', handleTabChange);
+
+        return () => window.removeEventListener('visibilitychange', handleTabChange);
+        
+    },[originalTitle])
+
+    return {
+        originalTitle,
+        setOriginalTitle
+    }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,8 +3,17 @@ import type { AppProps } from "next/app"
 import { ApolloProvider } from "@apollo/client"
 import client from "../apollo-client"
 import Script from "next/script"
+import { useEffect } from "react"
+import { useChangeTitle } from "../hooks/useChangeTitle"
 
 function MyApp({ Component, pageProps }: AppProps) {
+
+  const { originalTitle, setOriginalTitle } = useChangeTitle("😭 PLEASE COME BACK!!")
+
+  useEffect(() => {
+    if(!originalTitle) setOriginalTitle(document.title)
+  }, [originalTitle])
+
   return (
     <ApolloProvider client={client}>
       <Script


### PR DESCRIPTION
# Overview
Adding a dynamic title when the user is on another page or tab

![test](https://user-images.githubusercontent.com/46900196/219872625-f0f05b40-eed9-40a6-8a9a-750f78f6d2bd.gif)
